### PR TITLE
feat: Add CloudWatch client to emit custom metrics

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -13,6 +13,7 @@ mypy-boto3-bedrock = "*"
 mypy-boto3-bedrock-runtime = "*"
 mypy-boto3-ses = "*"
 mypy-boto3-secretsmanager = "*"
+mypy-boto3-cloudwatch = "*"
 
 [dev-packages]
 black = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "be50269ed0959c3afbda71745c1683b02908980d5c0129f63b26d4f173829461"
+            "sha256": "0c1dc9c08b49a6e7fcfd5cf85f8ae1bfce9adc6f038ad652d13bf4f5f5456d17"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -80,6 +80,14 @@
             "index": "pypi",
             "version": "==1.34.149"
         },
+        "mypy-boto3-cloudwatch": {
+            "hashes": [
+                "sha256:b4b48d91bc51c5a9a2c4219bb5d686414a2bf329d7e52dafa0efce8b30ac20e1",
+                "sha256:d53d369a72b8df3830999b68a988635894708dac71130b90509cb0530435c556"
+            ],
+            "index": "pypi",
+            "version": "==1.34.153"
+        },
         "mypy-boto3-dynamodb": {
             "hashes": [
                 "sha256:c85489b92cbbbe4f6997070372022df914d4cb8eb707fdc73aa18ce6ba25c578",
@@ -154,11 +162,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:a448b2f64d686155468037e1ace9f2d2199776e17f0a46610480d311f73e3472",
-                "sha256:dd505485549a7a552833da5e6063639d0d177c04f23bc3864e41e5dc5f612168"
+                "sha256:37a0344459b199fce0e80b0d3569837ec6b6937435c5244e7fd73fa6006830f3",
+                "sha256:3e3d753a8618b86d7de333b4223005f68720bcd6a7d2bcb9fbd2229ec7c1e429"
             ],
-            "markers": "python_version >= '3.10'",
-            "version": "==2.2.2"
+            "markers": "python_version < '3.10'",
+            "version": "==1.26.19"
         },
         "websockets": {
             "hashes": [
@@ -284,13 +292,21 @@
             "index": "pypi",
             "version": "==2.3.0"
         },
+        "exceptiongroup": {
+            "hashes": [
+                "sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b",
+                "sha256:47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc"
+            ],
+            "markers": "python_version < '3.11'",
+            "version": "==1.2.2"
+        },
         "flake8": {
             "hashes": [
-                "sha256:2e416edcc62471a64cea09353f4e7bdba32aeb079b6e360554c659a122b1bc6a",
-                "sha256:48a07b626b55236e0fb4784ee69a465fbf59d79eec1f5b4785c3d3bc57d17aa5"
+                "sha256:6fbe320aad8d6b95cec8b8e47bc933004678dc63095be98528b7bdd2a9f510db",
+                "sha256:7a1cf6b73744f5806ab95e526f6f0d8c01c66d7bbe349562d22dfca20610b248"
             ],
             "index": "pypi",
-            "version": "==7.1.0"
+            "version": "==5.0.4"
         },
         "iniconfig": {
             "hashes": [
@@ -350,19 +366,19 @@
         },
         "pycodestyle": {
             "hashes": [
-                "sha256:442f950141b4f43df752dd303511ffded3a04c2b6fb7f65980574f0c31e6e79c",
-                "sha256:949a39f6b86c3e1515ba1787c2022131d165a8ad271b11370a8819aa070269e4"
+                "sha256:2c9607871d58c76354b697b42f5d57e1ada7d261c261efac224b664affdc5785",
+                "sha256:d1735fc58b418fd7c5f658d28d943854f8a849b01a5d0a1e6f3f3fdd0166804b"
             ],
-            "markers": "python_version >= '3.8'",
-            "version": "==2.12.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==2.9.1"
         },
         "pyflakes": {
             "hashes": [
-                "sha256:1c61603ff154621fb2a9172037d84dca3500def8c8b630657d1701f026f8af3f",
-                "sha256:84b5be138a2dfbb40689ca07e2152deb896a65c3a3e24c251c5c62489568074a"
+                "sha256:4579f67d887f804e67edb544428f264b7b24f435b263c4614f384135cea553d2",
+                "sha256:491feb020dca48ccc562a8c0cbe8df07ee13078df59813b83959cbdada312ea3"
             ],
-            "markers": "python_version >= '3.8'",
-            "version": "==3.2.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==2.5.0"
         },
         "pytest": {
             "hashes": [
@@ -371,6 +387,22 @@
             ],
             "index": "pypi",
             "version": "==8.3.2"
+        },
+        "tomli": {
+            "hashes": [
+                "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
+                "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
+            ],
+            "markers": "python_version < '3.11'",
+            "version": "==2.0.1"
+        },
+        "typing-extensions": {
+            "hashes": [
+                "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d",
+                "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"
+            ],
+            "markers": "python_version < '3.12'",
+            "version": "==4.12.2"
         }
     }
 }

--- a/appspec.py
+++ b/appspec.py
@@ -1,4 +1,25 @@
+"""
+AppSpec Generator
+
+This script is responsible for creating an `appspec.yml` file for
+CodeDeploy deployments to bump the WalterAIBackend lambda from its
+current version to the latest version. This script is run during
+builds executed by CodeBuild and is dumped to S3 as an artifact to
+be used by CodeDeploy to execute the deployment.
+"""
+
+import os
+
 import boto3
+from src.environment import get_domain
+
+DOMAIN = get_domain(os.getenv("DOMAIN"))
+
+REGION = os.getenv("AWS_REGION")
+
+LAMBDA_NAME = f"WalterAIBackend-{DOMAIN.value}"
+
+LAMBDA_ALIAS = f"WalterAIBackend-{DOMAIN.value}"
 
 APPSPEC_TEMPLATE = """
 version: 0.0
@@ -14,13 +35,20 @@ Resources:
 """
 
 with open("./appspec.yml", "w") as appspec:
-    lambda_client = boto3.client("lambda", region_name="us-east-1")
+    # create lambda client
+    lambda_client = boto3.client("lambda", region_name=REGION)
+
+    # get current version the lambda is pointing to
     current_version = lambda_client.get_alias(
-        FunctionName="WalterAIBackend-dev", Name="WalterAIBackend-dev"
+        FunctionName=LAMBDA_NAME, Name=LAMBDA_ALIAS
     )["FunctionVersion"]
-    target_version = lambda_client.list_versions_by_function(
-        FunctionName="WalterAIBackend-dev"
-    )["Versions"][-1]["Version"]
+
+    # get the latest version of the lambda
+    target_version = lambda_client.list_versions_by_function(FunctionName=LAMBDA_NAME)[
+        "Versions"
+    ][-1]["Version"]
+
+    # generate appspec file bumping lambda from current version to latest version
     appspec.write(
         APPSPEC_TEMPLATE.format(
             current_version=current_version, target_version=target_version

--- a/infra/infra.yml
+++ b/infra/infra.yml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: "2010-09-09"
-Description: "WalterAI Backend Infrastructure"
+Description: "WalterAIBackend Infrastructure"
 
 Parameters:
   AppEnvironment:
@@ -12,11 +12,23 @@ Parameters:
       - prod
 
 Resources:
+
+  ##############
+  ### LAMBDA ###
+  ##############
+
+  WalterAIBackendFunctionAlias:
+    Type: AWS::Lambda::Alias
+    Properties:
+      FunctionName: !Ref WalterAIBackendFunction
+      FunctionVersion: $LATEST
+      Name: !Sub "WalterAIBackend-${AppEnvironment}"
+
   WalterAIBackendFunction:
       Type: AWS::Lambda::Function
       Properties:
         FunctionName: !Sub "WalterAIBackend-${AppEnvironment}"
-        Description: !Sub "WalterAI Backend Lambda (${AppEnvironment})"
+        Description: !Sub "WalterAIBackend Lambda (${AppEnvironment})"
         Handler: walter_ai.lambda_handler
         Role: !Join
           - ""
@@ -32,34 +44,17 @@ Resources:
         Architectures:
           - "arm64"
         Layers:
-          - "arn:aws:lambda:us-east-1:010526272437:layer:WalterAILambdaLayer:15"
+          - !Join
+            - ""
+            - - "arn:aws:lambda:"
+              - !Ref "AWS::Region"
+              - ":"
+              - !Ref "AWS::AccountId"
+              - ":layer:"
+              - "WalterAILambdaLayer:15"
         Environment:
           Variables:
             DOMAIN: DEVELOPMENT
-
-  WalterAIBackendFunctionAlias:
-    Type: AWS::Lambda::Alias
-    Properties:
-      FunctionName: !Ref WalterAIBackendFunction
-      FunctionVersion: $LATEST
-      Name: !Sub "WalterAIBackend-${AppEnvironment}"
-
-  WalterLambdaRole:
-    Type: AWS::IAM::Role
-    Properties:
-      RoleName: !Sub "WalterAILambaExecutionRole-${AppEnvironment}"
-      Description: "Walter AI Lambda execution role"
-      AssumeRolePolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          - Action:
-              - "sts:AssumeRole"
-            Effect: Allow
-            Principal:
-              Service:
-                - "lambda.amazonaws.com"
-      ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
 
   WalterDailyScheduler:
     Type: AWS::Events::Rule
@@ -82,19 +77,9 @@ Resources:
               "body": {}
             }
 
-  BedrockAccessPolicy:
-    Type: AWS::IAM::Policy
-    Properties:
-      PolicyName: !Sub "BedrockAccessPolicy-${AppEnvironment}"
-      PolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          - Effect: Allow
-            Action:
-              - "bedrock:InvokeModel"
-            Resource: "arn:aws:bedrock:us-east-1::foundation-model/meta.llama3-70b-instruct-v1:0"
-      Roles:
-        - !Ref WalterLambdaRole
+  ################
+  ### DYNAMODB ###
+  ################
 
   StocksTable:
     Type: AWS::DynamoDB::Table
@@ -107,74 +92,6 @@ Resources:
           - AttributeName: symbol
             KeyType: HASH
       TableName: !Sub "Stocks-${AppEnvironment}"
-
-  StocksTableAccessPolicy:
-    Type: AWS::IAM::Policy
-    Properties:
-      PolicyName: !Sub "StocksTableAccessPolicy-${AppEnvironment}"
-      PolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          - Effect: Allow
-            Action:
-              - "dynamodb:BatchGet*"
-              - "dynamodb:Get*"
-              - "dynamodb:Query"
-              - "dynamodb:Scan"
-              - "dynamodb:BatchWrite*"
-              - "dynamodb:Delete*"
-              - "dynamodb:Update*"
-              - "dynamodb:PutItem"
-            Resource: !Join
-              - ""
-              - - "arn:aws:dynamodb:"
-                - !Ref "AWS::Region"
-                - ":"
-                - !Ref "AWS::AccountId"
-                - ":table/"
-                - !Ref StocksTable 
-      Roles:
-        - !Ref WalterLambdaRole
-
-  UsersTable:
-    Type: AWS::DynamoDB::Table
-    Properties:
-      AttributeDefinitions:
-        - AttributeName: email
-          AttributeType: S
-      BillingMode: PAY_PER_REQUEST
-      KeySchema:
-          - AttributeName: email
-            KeyType: HASH
-      TableName: !Sub "Users-${AppEnvironment}"
-
-  UsersTableAccessPolicy:
-    Type: AWS::IAM::Policy
-    Properties:
-      PolicyName: !Sub "UsersTableAccessPolicy-${AppEnvironment}"
-      PolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          - Effect: Allow
-            Action:
-              - "dynamodb:BatchGet*"
-              - "dynamodb:Get*"
-              - "dynamodb:Query"
-              - "dynamodb:Scan"
-              - "dynamodb:BatchWrite*"
-              - "dynamodb:Delete*"
-              - "dynamodb:Update*"
-              - "dynamodb:PutItem"
-            Resource: !Join
-              - ""
-              - - "arn:aws:dynamodb:"
-                - !Ref "AWS::Region"
-                - ":"
-                - !Ref "AWS::AccountId"
-                - ":table/"
-                - !Ref UsersTable 
-      Roles:
-        - !Ref WalterLambdaRole
 
   UsersStocksTable:
     Type: AWS::DynamoDB::Table
@@ -192,67 +109,70 @@ Resources:
             KeyType: RANGE
       TableName: !Sub "UsersStocks-${AppEnvironment}"
 
-  UsersStocksTableAccessPolicy:
+  UsersTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      AttributeDefinitions:
+        - AttributeName: email
+          AttributeType: S
+      BillingMode: PAY_PER_REQUEST
+      KeySchema:
+          - AttributeName: email
+            KeyType: HASH
+      TableName: !Sub "Users-${AppEnvironment}"
+
+  #################
+  ### IAM ROLES ###
+  #################
+
+  WalterLambdaRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "WalterAILambaExecutionRole-${AppEnvironment}"
+      Description: "Walter AI Lambda execution role"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Action:
+              - "sts:AssumeRole"
+            Effect: Allow
+            Principal:
+              Service:
+                - "lambda.amazonaws.com"
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+
+  ####################
+  ### IAM POLICIES ###
+  ####################
+
+  BedrockAccessPolicy:
     Type: AWS::IAM::Policy
     Properties:
-      PolicyName: !Sub "UsersStocksTableAccessPolicy-${AppEnvironment}"
+      PolicyName: !Sub "BedrockAccessPolicy-${AppEnvironment}"
       PolicyDocument:
         Version: "2012-10-17"
         Statement:
           - Effect: Allow
             Action:
-              - "dynamodb:BatchGet*"
-              - "dynamodb:Get*"
-              - "dynamodb:Query"
-              - "dynamodb:Scan"
-              - "dynamodb:BatchWrite*"
-              - "dynamodb:Delete*"
-              - "dynamodb:Update*"
-              - "dynamodb:PutItem"
-            Resource: !Join
-              - ""
-              - - "arn:aws:dynamodb:"
-                - !Ref "AWS::Region"
-                - ":"
-                - !Ref "AWS::AccountId"
-                - ":table/"
-                - !Ref UsersStocksTable 
+              - "bedrock:InvokeModel"
+            Resource: "arn:aws:bedrock:us-east-1::foundation-model/meta.llama3-70b-instruct-v1:0"
       Roles:
         - !Ref WalterLambdaRole
-
-  ReportsBucket:
-    Type: AWS::S3::Bucket
+  
+  CloudWatchAccessPolicy:
+    Type: AWS::IAM::Policy
     Properties:
-      BucketName: !Sub "walterai-reports-${AppEnvironment}"
-      BucketEncryption:
-        ServerSideEncryptionConfiguration:
-          - ServerSideEncryptionByDefault:
-              SSEAlgorithm: "AES256"
-      VersioningConfiguration:
-        Status: Enabled
-
-  ReportsBucketPolicy:
-    Type: AWS::S3::BucketPolicy
-    Properties:
-      Bucket: !Ref ReportsBucket
+      PolicyName: !Sub "CloudWatchAccessPolicy-${AppEnvironment}"
       PolicyDocument:
         Version: "2012-10-17"
-        Statement: 
-          - Action: 
-              - "s3:PutObject"
-            Effect: Allow
-            Resource: !Join
-              - ""
-              - - "arn:aws:s3:::"
-                - !Ref ReportsBucket
-                - "/*" 
-            Principal: 
-              AWS: !Join
-                - ""
-                - - "arn:aws:iam::"
-                  - !Ref "AWS::AccountId"
-                  - ":role/"
-                  - !Ref WalterLambdaRole
+        Statement:
+          - Effect: Allow
+            Action:
+              - "cloudwatch:PutMetricData"
+            Resource: "*"
+      Roles:
+        - !Ref WalterLambdaRole
 
   ReportsBucketAccessPolicy:
     Type: AWS::IAM::Policy
@@ -291,3 +211,125 @@ Resources:
                 - ":secret:PolygonAPIKey-vZymuJ"
       Roles:
         - !Ref WalterLambdaRole
+
+  StocksTableAccessPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: !Sub "StocksTableAccessPolicy-${AppEnvironment}"
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - "dynamodb:BatchGet*"
+              - "dynamodb:Get*"
+              - "dynamodb:Query"
+              - "dynamodb:Scan"
+              - "dynamodb:BatchWrite*"
+              - "dynamodb:Delete*"
+              - "dynamodb:Update*"
+              - "dynamodb:PutItem"
+            Resource: !Join
+              - ""
+              - - "arn:aws:dynamodb:"
+                - !Ref "AWS::Region"
+                - ":"
+                - !Ref "AWS::AccountId"
+                - ":table/"
+                - !Ref StocksTable 
+      Roles:
+        - !Ref WalterLambdaRole
+
+  UsersStocksTableAccessPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: !Sub "UsersStocksTableAccessPolicy-${AppEnvironment}"
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - "dynamodb:BatchGet*"
+              - "dynamodb:Get*"
+              - "dynamodb:Query"
+              - "dynamodb:Scan"
+              - "dynamodb:BatchWrite*"
+              - "dynamodb:Delete*"
+              - "dynamodb:Update*"
+              - "dynamodb:PutItem"
+            Resource: !Join
+              - ""
+              - - "arn:aws:dynamodb:"
+                - !Ref "AWS::Region"
+                - ":"
+                - !Ref "AWS::AccountId"
+                - ":table/"
+                - !Ref UsersStocksTable 
+      Roles:
+        - !Ref WalterLambdaRole
+
+  UsersTableAccessPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: !Sub "UsersTableAccessPolicy-${AppEnvironment}"
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - "dynamodb:BatchGet*"
+              - "dynamodb:Get*"
+              - "dynamodb:Query"
+              - "dynamodb:Scan"
+              - "dynamodb:BatchWrite*"
+              - "dynamodb:Delete*"
+              - "dynamodb:Update*"
+              - "dynamodb:PutItem"
+            Resource: !Join
+              - ""
+              - - "arn:aws:dynamodb:"
+                - !Ref "AWS::Region"
+                - ":"
+                - !Ref "AWS::AccountId"
+                - ":table/"
+                - !Ref UsersTable 
+      Roles:
+        - !Ref WalterLambdaRole
+
+  ##########
+  ### S3 ###
+  ##########
+
+  ReportsBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub "walterai-reports-${AppEnvironment}"
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: "AES256"
+      VersioningConfiguration:
+        Status: Enabled
+
+  ReportsBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref ReportsBucket
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement: 
+          - Action: 
+              - "s3:PutObject"
+            Effect: Allow
+            Resource: !Join
+              - ""
+              - - "arn:aws:s3:::"
+                - !Ref ReportsBucket
+                - "/*" 
+            Principal: 
+              AWS: !Join
+                - ""
+                - - "arn:aws:iam::"
+                  - !Ref "AWS::AccountId"
+                  - ":role/"
+                  - !Ref WalterLambdaRole

--- a/infra/infra.yml
+++ b/infra/infra.yml
@@ -51,7 +51,7 @@ Resources:
               - ":"
               - !Ref "AWS::AccountId"
               - ":layer:"
-              - "WalterAILambdaLayer:15"
+              - "WalterAILambdaLayer:16"
         Environment:
           Variables:
             DOMAIN: DEVELOPMENT

--- a/src/clients.py
+++ b/src/clients.py
@@ -2,14 +2,15 @@ import os
 
 import boto3
 from src.bedrock.client import BedrockClient
+from src.cloudwatch.client import CloudWatchClient
 from src.dynamodb.client import DDBClient
 from src.environment import get_domain
 from src.polygon.client import PolygonClient
+from src.report.generator import ReportGenerator
 from src.s3.client import S3Client
+from src.secretsmanager.client import SecretsManagerClient
 from src.ses.client import SESClient
 from src.utils.log import Logger
-from src.report.generator import ReportGenerator
-from src.secretsmanager.client import SecretsManagerClient
 
 log = Logger(__name__).get_logger()
 
@@ -25,6 +26,7 @@ bedrock = BedrockClient(
     bedrock=boto3.client("bedrock", region_name=AWS_REGION),
     bedrock_runtime=boto3.client("bedrock-runtime", region_name=AWS_REGION),
 )
+cloudwatch = CloudWatchClient(client=boto3.client("cloudwatch", region_name=AWS_REGION))
 ddb = DDBClient(client=boto3.client("dynamodb", region_name=AWS_REGION), domain=DOMAIN)
 s3 = S3Client(client=boto3.client("s3", region_name=AWS_REGION), domain=DOMAIN)
 ses = SESClient(client=boto3.client("ses", region_name=AWS_REGION), domain=DOMAIN)

--- a/src/cloudwatch/client.py
+++ b/src/cloudwatch/client.py
@@ -1,0 +1,77 @@
+from dataclasses import dataclass
+
+from mypy_boto3_cloudwatch import CloudWatchClient
+from src.environment import Domain
+from src.utils.log import Logger
+
+log = Logger(__name__).get_logger()
+
+
+@dataclass
+class CloudWatchClient:
+    """
+    WalterAI CloudWatch Client
+
+    Metrics:
+        - The number of emails sent
+        - The number of stocks analyzed
+        - The number of subscribed users
+    """
+
+    METRIC_NAME_NUMBER_OF_EMAILS_SENT = "NumberOfEmailsSent-{domain}"
+    METRIC_NAME_NUMBER_OF_STOCKS_ANALYZED = "NumberOfStocksAnalyzed-{domain}"
+    METRIC_NAME_NUMBER_OF_SUBSCRIBED_USERS = "NumberOfSubscribedUsers-{domain}"
+
+    client: CloudWatchClient
+    domain: Domain
+
+    metric_name_number_of_emails_sent: str = None
+    metric_name_number_of_stocks_analyzed: str = None
+    metric_name_number_of_subscribed_users: str = None
+
+    def __post_init__(self) -> None:
+        log.debug(
+            f"Creating {self.domain.value} CloudWatch client in region '{self.client.meta.region_name}'"
+        )
+        self.metric_name_number_of_emails_sent = (
+            CloudWatchClient._get_number_of_emails_sent_metric_name(self.domain)
+        )
+        self.metric_name_number_of_stocks_analyzed = (
+            CloudWatchClient._get_number_of_stocks_analyzed_metric_name(self.domain)
+        )
+        self.metric_name_number_of_subscribed_users = (
+            CloudWatchClient._get_number_of_subscribed_users_metric_name(self.domain)
+        )
+
+    def emit_metric_number_of_emails_sent(self, num_emails: int) -> None:
+        self.client.put_metric_data(
+            MetricName=self.metric_name_number_of_emails_sent, Value=num_emails
+        )
+
+    def emit_metric_number_of_stocks_analyzed(self, num_stocks: int) -> None:
+        self.client.put_metric_data(
+            MetricName=self.metric_name_number_of_stocks_analyzed, Value=num_stocks
+        )
+
+    def emit_metric_number_of_subscribed_users(self, num_users: int) -> None:
+        self.client.put_metric_data(
+            MetricName=self.metric_name_number_of_subscribed_users, Value=num_users
+        )
+
+    @staticmethod
+    def _get_number_of_emails_sent_metric_name(domain: Domain) -> str:
+        return CloudWatchClient.METRIC_NAME_NUMBER_OF_EMAILS_SENT.format(
+            domain=domain.value
+        )
+
+    @staticmethod
+    def _get_number_of_stocks_analyzed_metric_name(domain: Domain) -> str:
+        return CloudWatchClient.METRIC_NAME_NUMBER_OF_STOCKS_ANALYZED.format(
+            domain=domain.value
+        )
+
+    @staticmethod
+    def _get_number_of_subscribed_users_metric_name(domain: Domain) -> str:
+        return CloudWatchClient.METRIC_NAME_NUMBER_OF_SUBSCRIBED_USERS.format(
+            domain=domain.value
+        )

--- a/walter_ai.py
+++ b/walter_ai.py
@@ -1,7 +1,7 @@
 import json
-
-from src.clients import ddb, polygon, report_generator, bedrock
 from datetime import datetime, timedelta
+
+from src.clients import bedrock, cloudwatch, ddb, polygon, report_generator
 
 END_DATE = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
 START_DATE = END_DATE - timedelta(days=1)
@@ -9,15 +9,17 @@ START_DATE = END_DATE - timedelta(days=1)
 
 def lambda_handler(event, context) -> dict:
     # get stocks from ddb and get prices from polygon
-    stocks = []
-    for stock in ddb.get_stocks():
-        stocks.extend(polygon.get_prices(stock.symbol, START_DATE, END_DATE))
+    prices = []
+    stocks = ddb.get_stocks()
+    for stock in stocks:
+        prices.extend(polygon.get_prices(stock.symbol, START_DATE, END_DATE))
 
     # ingest stock data into report generator
-    report_generator.ingest_stocks(stocks)
+    report_generator.ingest_stocks(prices)
 
     # generate report for each user
-    for user in ddb.get_users():
+    users = ddb.get_users()
+    for user in users:
 
         # get stocks for user from ddb
         stocks = ddb.get_stocks_for_user(user)
@@ -30,5 +32,10 @@ def lambda_handler(event, context) -> dict:
 
         # TODO: print ai report until emailing via ses is implemented
         print(ai_report)
+
+    # emit metrics
+    cloudwatch.emit_metric_number_of_emails_sent(len(users))
+    cloudwatch.emit_metric_number_of_stocks_analyzed(len(stocks))
+    cloudwatch.emit_metric_number_of_subscribed_users(len(users))
 
     return {"statusCode": 200, "body": json.dumps("Walter AI")}


### PR DESCRIPTION
This PR adds a CloudWatch client to `WalterAIBackend` that emits custom metrics about number of emails sent, number of stocks analyzed, and number of subscribed users. 

Added an additional IAM policy and attached it to the Lambda execution role so that the function can actually emit the metrics. Took some time to organize the CFN template as well since it's getting large.

Add new dependency on `mypy-boto3-cloudwatch` so bumped lambda layer version. 