### PR TITLE
fix: Fix CloudWatch put metric data namespace

### DIFF
--- a/src/cloudwatch/client.py
+++ b/src/cloudwatch/client.py
@@ -72,4 +72,4 @@ class CloudWatchClient:
 
     @staticmethod
     def _get_metric_namespace(domain: Domain) -> str:
-        return CloudWatchClient.METRIC_NAMESPACE.format(domain=domain)
+        return CloudWatchClient.METRIC_NAMESPACE.format(domain=domain.value)


### PR DESCRIPTION
Yooooooo hope this is the last CR about CloudWatch custom metrics for now 💯 

Using the `domain.value` like `dev`, `preprod`, and `prod` in the metric namespace, e.g.:

* `WalterAIBackend/dev/NumberOfEmailsSent`

Not bad format, kind of want domain to be different but fine for now.