### PR TITLE
feat: Improve build script to handle CloudFormation updates gracefully

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -14,6 +14,7 @@ mypy-boto3-bedrock-runtime = "*"
 mypy-boto3-ses = "*"
 mypy-boto3-secretsmanager = "*"
 mypy-boto3-cloudwatch = "*"
+mypy-boto3-cloudformation = "*"
 
 [dev-packages]
 black = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "0c1dc9c08b49a6e7fcfd5cf85f8ae1bfce9adc6f038ad652d13bf4f5f5456d17"
+            "sha256": "b1d07380a08b40fea351540f70453383e1af28d6f107796a8f18bcf820f5acb2"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -79,6 +79,14 @@
             ],
             "index": "pypi",
             "version": "==1.34.149"
+        },
+        "mypy-boto3-cloudformation": {
+            "hashes": [
+                "sha256:526e928c504fa2880b1774aa10629a04fe0ec70ed2864ab3d3f7772386a1a925",
+                "sha256:a02e201d1a9d9a8fb4db5b942d5c537a4e8861c611f0d986126674ac557cb9e8"
+            ],
+            "index": "pypi",
+            "version": "==1.34.111"
         },
         "mypy-boto3-cloudwatch": {
             "hashes": [

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -8,6 +8,7 @@ phases:
       - echo Installing AWS CLI and Boto3
       - pip install --upgrade awscli
       - pip install boto3
+      - pip install mypy-boto3-cloudformation
   pre_build:
     commands:
     - echo Updating WalterAIBackend infrastructure via CloudFormation

--- a/infra/infra.yml
+++ b/infra/infra.yml
@@ -4,7 +4,7 @@ Description: "WalterAIBackend Infrastructure"
 Parameters:
   AppEnvironment:
     Type: String
-    Description: The environment of the Walter AI stack
+    Description: The environment of the WalterAIBackend stack
     Default: dev
     AllowedValues:
       - dev
@@ -28,7 +28,7 @@ Resources:
       Type: AWS::Lambda::Function
       Properties:
         FunctionName: !Sub "WalterAIBackend-${AppEnvironment}"
-        Description: !Sub "WalterAIBackend Lambda Function (${AppEnvironment})"
+        Description: !Sub "WalterAIBackend Lambda (${AppEnvironment})"
         Handler: walter_ai.lambda_handler
         Role: !Join
           - ""


### PR DESCRIPTION
This PR improves the `buildspec.py` script to handle CloudFormation updates more gracefully.

If the CFN stack does not exist, it creates it. If the CFN stack does exist, this script checks for changes first before executing the updates to ensure resources do not drift from IaC file. 