### PR TITLE
feat: Pull newsletter templates from S3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ secrets.sh
 *.log
 .pytest_cache
 local.py
+templates

--- a/Pipfile
+++ b/Pipfile
@@ -16,12 +16,14 @@ mypy-boto3-secretsmanager = "*"
 mypy-boto3-cloudwatch = "*"
 mypy-boto3-cloudformation = "*"
 mypy-boto3-lambda = "*"
+jinja2 = "*"
 
 [dev-packages]
 black = "*"
 flake8 = "*"
 pytest = "*"
 codespell = "*"
+isort = "*"
 
 [requires]
 python_version = "3.11"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "0a5c69e9d4043434f83e083dc9441f4121fa32f19f5b8dbb464fb06c98a4a2eb"
+            "sha256": "abedf45cfb92acc9857ed900ebdb391e03f1be565ea7821b99e9cceb356d6895"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,19 +18,19 @@
     "default": {
         "boto3": {
             "hashes": [
-                "sha256:b33e9a8f8be80d3053b8418836a7c1900410b23a30c7cb040927d601a1082e68",
-                "sha256:cbbd453270b8ce94ef9da60dfbb6f9ceeb3eeee226b635aa9ec44b1def98cc96"
+                "sha256:5b7b2ce0ec1e498933f600d29f3e1c641f8c44dd7e468c26795359d23d81fa39",
+                "sha256:c29e9b7e1034e8734ccaffb9f2b3f3df2268022fd8a93d836604019f8759ce27"
             ],
             "index": "pypi",
-            "version": "==1.34.156"
+            "version": "==1.34.158"
         },
         "botocore": {
             "hashes": [
-                "sha256:5d1478c41ab9681e660b3322432fe09c4055759c317984b7b8d3af9557ff769a",
-                "sha256:c48f8c8996216dfdeeb0aa6d3c0f2c7ae25234766434a2ea3e57bdc08494bdda"
+                "sha256:0e6fceba1e39bfa8feeba70ba3ac2af958b3387df4bd3b5f2db3f64c1754c756",
+                "sha256:5934082e25ad726673afbf466092fb1223dafa250e6e756c819430ba6b1b3da5"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.34.156"
+            "version": "==1.34.158"
         },
         "certifi": {
             "hashes": [
@@ -56,6 +56,14 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==10.0"
         },
+        "jinja2": {
+            "hashes": [
+                "sha256:4a3aee7acbbe7303aede8e9648d13b8bf88a429282aa6122a993f0ac800cb369",
+                "sha256:bc5dd2abb727a5319567b7a813e6a2e7318c39f4f487cfe6c89c6f9c7d25197d"
+            ],
+            "index": "pypi",
+            "version": "==3.1.4"
+        },
         "jmespath": {
             "hashes": [
                 "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980",
@@ -63,6 +71,72 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==1.0.1"
+        },
+        "markupsafe": {
+            "hashes": [
+                "sha256:00e046b6dd71aa03a41079792f8473dc494d564611a8f89bbbd7cb93295ebdcf",
+                "sha256:075202fa5b72c86ad32dc7d0b56024ebdbcf2048c0ba09f1cde31bfdd57bcfff",
+                "sha256:0e397ac966fdf721b2c528cf028494e86172b4feba51d65f81ffd65c63798f3f",
+                "sha256:17b950fccb810b3293638215058e432159d2b71005c74371d784862b7e4683f3",
+                "sha256:1f3fbcb7ef1f16e48246f704ab79d79da8a46891e2da03f8783a5b6fa41a9532",
+                "sha256:2174c595a0d73a3080ca3257b40096db99799265e1c27cc5a610743acd86d62f",
+                "sha256:2b7c57a4dfc4f16f7142221afe5ba4e093e09e728ca65c51f5620c9aaeb9a617",
+                "sha256:2d2d793e36e230fd32babe143b04cec8a8b3eb8a3122d2aceb4a371e6b09b8df",
+                "sha256:30b600cf0a7ac9234b2638fbc0fb6158ba5bdcdf46aeb631ead21248b9affbc4",
+                "sha256:397081c1a0bfb5124355710fe79478cdbeb39626492b15d399526ae53422b906",
+                "sha256:3a57fdd7ce31c7ff06cdfbf31dafa96cc533c21e443d57f5b1ecc6cdc668ec7f",
+                "sha256:3c6b973f22eb18a789b1460b4b91bf04ae3f0c4234a0a6aa6b0a92f6f7b951d4",
+                "sha256:3e53af139f8579a6d5f7b76549125f0d94d7e630761a2111bc431fd820e163b8",
+                "sha256:4096e9de5c6fdf43fb4f04c26fb114f61ef0bf2e5604b6ee3019d51b69e8c371",
+                "sha256:4275d846e41ecefa46e2015117a9f491e57a71ddd59bbead77e904dc02b1bed2",
+                "sha256:4c31f53cdae6ecfa91a77820e8b151dba54ab528ba65dfd235c80b086d68a465",
+                "sha256:4f11aa001c540f62c6166c7726f71f7573b52c68c31f014c25cc7901deea0b52",
+                "sha256:5049256f536511ee3f7e1b3f87d1d1209d327e818e6ae1365e8653d7e3abb6a6",
+                "sha256:58c98fee265677f63a4385256a6d7683ab1832f3ddd1e66fe948d5880c21a169",
+                "sha256:598e3276b64aff0e7b3451b72e94fa3c238d452e7ddcd893c3ab324717456bad",
+                "sha256:5b7b716f97b52c5a14bffdf688f971b2d5ef4029127f1ad7a513973cfd818df2",
+                "sha256:5dedb4db619ba5a2787a94d877bc8ffc0566f92a01c0ef214865e54ecc9ee5e0",
+                "sha256:619bc166c4f2de5caa5a633b8b7326fbe98e0ccbfacabd87268a2b15ff73a029",
+                "sha256:629ddd2ca402ae6dbedfceeba9c46d5f7b2a61d9749597d4307f943ef198fc1f",
+                "sha256:656f7526c69fac7f600bd1f400991cc282b417d17539a1b228617081106feb4a",
+                "sha256:6ec585f69cec0aa07d945b20805be741395e28ac1627333b1c5b0105962ffced",
+                "sha256:72b6be590cc35924b02c78ef34b467da4ba07e4e0f0454a2c5907f473fc50ce5",
+                "sha256:7502934a33b54030eaf1194c21c692a534196063db72176b0c4028e140f8f32c",
+                "sha256:7a68b554d356a91cce1236aa7682dc01df0edba8d043fd1ce607c49dd3c1edcf",
+                "sha256:7b2e5a267c855eea6b4283940daa6e88a285f5f2a67f2220203786dfa59b37e9",
+                "sha256:823b65d8706e32ad2df51ed89496147a42a2a6e01c13cfb6ffb8b1e92bc910bb",
+                "sha256:8590b4ae07a35970728874632fed7bd57b26b0102df2d2b233b6d9d82f6c62ad",
+                "sha256:8dd717634f5a044f860435c1d8c16a270ddf0ef8588d4887037c5028b859b0c3",
+                "sha256:8dec4936e9c3100156f8a2dc89c4b88d5c435175ff03413b443469c7c8c5f4d1",
+                "sha256:97cafb1f3cbcd3fd2b6fbfb99ae11cdb14deea0736fc2b0952ee177f2b813a46",
+                "sha256:a17a92de5231666cfbe003f0e4b9b3a7ae3afb1ec2845aadc2bacc93ff85febc",
+                "sha256:a549b9c31bec33820e885335b451286e2969a2d9e24879f83fe904a5ce59d70a",
+                "sha256:ac07bad82163452a6884fe8fa0963fb98c2346ba78d779ec06bd7a6262132aee",
+                "sha256:ae2ad8ae6ebee9d2d94b17fb62763125f3f374c25618198f40cbb8b525411900",
+                "sha256:b91c037585eba9095565a3556f611e3cbfaa42ca1e865f7b8015fe5c7336d5a5",
+                "sha256:bc1667f8b83f48511b94671e0e441401371dfd0f0a795c7daa4a3cd1dde55bea",
+                "sha256:bec0a414d016ac1a18862a519e54b2fd0fc8bbfd6890376898a6c0891dd82e9f",
+                "sha256:bf50cd79a75d181c9181df03572cdce0fbb75cc353bc350712073108cba98de5",
+                "sha256:bff1b4290a66b490a2f4719358c0cdcd9bafb6b8f061e45c7a2460866bf50c2e",
+                "sha256:c061bb86a71b42465156a3ee7bd58c8c2ceacdbeb95d05a99893e08b8467359a",
+                "sha256:c8b29db45f8fe46ad280a7294f5c3ec36dbac9491f2d1c17345be8e69cc5928f",
+                "sha256:ce409136744f6521e39fd8e2a24c53fa18ad67aa5bc7c2cf83645cce5b5c4e50",
+                "sha256:d050b3361367a06d752db6ead6e7edeb0009be66bc3bae0ee9d97fb326badc2a",
+                "sha256:d283d37a890ba4c1ae73ffadf8046435c76e7bc2247bbb63c00bd1a709c6544b",
+                "sha256:d9fad5155d72433c921b782e58892377c44bd6252b5af2f67f16b194987338a4",
+                "sha256:daa4ee5a243f0f20d528d939d06670a298dd39b1ad5f8a72a4275124a7819eff",
+                "sha256:db0b55e0f3cc0be60c1f19efdde9a637c32740486004f20d1cff53c3c0ece4d2",
+                "sha256:e61659ba32cf2cf1481e575d0462554625196a1f2fc06a1c777d3f48e8865d46",
+                "sha256:ea3d8a3d18833cf4304cd2fc9cbb1efe188ca9b5efef2bdac7adc20594a0e46b",
+                "sha256:ec6a563cff360b50eed26f13adc43e61bc0c04d94b8be985e6fb24b81f6dcfdf",
+                "sha256:f5dfb42c4604dddc8e4305050aa6deb084540643ed5804d7455b5df8fe16f5e5",
+                "sha256:fa173ec60341d6bb97a89f5ea19c85c5643c1e7dedebc22f5181eb73573142c5",
+                "sha256:fa9db3f79de01457b03d4f01b34cf91bc0048eb2c3846ff26f66687c2f6d16ab",
+                "sha256:fce659a462a1be54d2ffcacea5e3ba2d74daa74f30f5f143fe0c58636e355fdd",
+                "sha256:ffee1f21e5ef0d712f9033568f8344d5da8cc2869dbd08d87c84656e6a2d2f68"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==2.1.5"
         },
         "mypy-boto3-bedrock": {
             "hashes": [
@@ -178,11 +252,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:a448b2f64d686155468037e1ace9f2d2199776e17f0a46610480d311f73e3472",
-                "sha256:dd505485549a7a552833da5e6063639d0d177c04f23bc3864e41e5dc5f612168"
+                "sha256:37a0344459b199fce0e80b0d3569837ec6b6937435c5244e7fd73fa6006830f3",
+                "sha256:3e3d753a8618b86d7de333b4223005f68720bcd6a7d2bcb9fbd2229ec7c1e429"
             ],
-            "markers": "python_version >= '3.10'",
-            "version": "==2.2.2"
+            "markers": "python_version < '3.10'",
+            "version": "==1.26.19"
         },
         "websockets": {
             "hashes": [
@@ -308,6 +382,14 @@
             "index": "pypi",
             "version": "==2.3.0"
         },
+        "exceptiongroup": {
+            "hashes": [
+                "sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b",
+                "sha256:47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc"
+            ],
+            "markers": "python_version < '3.11'",
+            "version": "==1.2.2"
+        },
         "flake8": {
             "hashes": [
                 "sha256:049d058491e228e03e67b390f311bbf88fce2dbaa8fa673e7aea87b7198b8d38",
@@ -323,6 +405,14 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==2.0.0"
+        },
+        "isort": {
+            "hashes": [
+                "sha256:48fdfcb9face5d58a4f6dde2e72a1fb8dcaf8ab26f95ab49fab84c2ddefb0109",
+                "sha256:8ca5e72a8d85860d5a3fa69b8745237f2939afe12dbf656afbcb47fe72d947a6"
+            ],
+            "index": "pypi",
+            "version": "==5.13.2"
         },
         "mccabe": {
             "hashes": [
@@ -395,6 +485,22 @@
             ],
             "index": "pypi",
             "version": "==8.3.2"
+        },
+        "tomli": {
+            "hashes": [
+                "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
+                "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
+            ],
+            "markers": "python_version < '3.11'",
+            "version": "==2.0.1"
+        },
+        "typing-extensions": {
+            "hashes": [
+                "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d",
+                "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"
+            ],
+            "markers": "python_version < '3.12'",
+            "version": "==4.12.2"
         }
     }
 }

--- a/infra/infra.yml
+++ b/infra/infra.yml
@@ -29,7 +29,7 @@ Resources:
       Properties:
         FunctionName: !Sub "WalterAIBackend-${AppEnvironment}"
         Description: !Sub "WalterAIBackend Lambda (${AppEnvironment})"
-        Handler: walter_ai.lambda_handler
+        Handler: walter.lambda_handler
         Role: !Join
           - ""
           - - "arn:aws:iam::"
@@ -51,7 +51,7 @@ Resources:
               - ":"
               - !Ref "AWS::AccountId"
               - ":layer:"
-              - "WalterAILambdaLayer:16"
+              - "WalterAILambdaLayer:17"
         Environment:
           Variables:
             DOMAIN: DEVELOPMENT

--- a/src/bedrock/client.py
+++ b/src/bedrock/client.py
@@ -1,8 +1,10 @@
 import json
 from dataclasses import dataclass
+from typing import List
 
 from mypy_boto3_bedrock import BedrockClient
 from mypy_boto3_bedrock_runtime import BedrockRuntimeClient
+from src.jinja.models import Parameter, Response
 from src.utils.log import Logger
 
 log = Logger(__name__).get_logger()
@@ -32,10 +34,19 @@ class BedrockClient:
             f"Creating Bedrock client in region '{self.bedrock.meta.region_name}'"
         )
 
+    def generate_responses(self, parameters: List[Parameter]) -> List[Response]:
+        log.info(f"Generating AI response for {len(parameters)} prompts")
+        responses = []
+        for parameter in parameters:
+            responses.append(
+                Response(parameter.key, self.generate_response(parameter.prompt))
+            )
+        return responses
+
     def generate_response(self, prompt: str) -> str:
         try:
             log.info(
-                f"Generating response with model {BedrockClient.META_LLAMA3_8B_MODEL_ID}"
+                f"Generating response with model {BedrockClient.META_LLAMA3_8B_MODEL_ID}:\n{prompt}"
             )
             response = self.bedrock_runtime.invoke_model(
                 modelId=BedrockClient.META_LLAMA3_8B_MODEL_ID,

--- a/src/clients.py
+++ b/src/clients.py
@@ -5,6 +5,7 @@ from src.bedrock.client import BedrockClient
 from src.cloudwatch.client import CloudWatchClient
 from src.dynamodb.client import DDBClient
 from src.environment import get_domain
+from src.jinja.client import TemplateEngine
 from src.polygon.client import PolygonClient
 from src.report.generator import ReportGenerator
 from src.s3.client import S3Client
@@ -38,6 +39,12 @@ secretsmanager = SecretsManagerClient(
     client=boto3.client("secretsmanager", region_name=AWS_REGION), domain=DOMAIN
 )
 ses = SESClient(client=boto3.client("ses", region_name=AWS_REGION), domain=DOMAIN)
+
+#########################
+# JINJA TEMPLATE ENGINE #
+#########################
+
+template_engine = TemplateEngine(s3_client=s3)
 
 ##################
 # POLYGON CLIENT #

--- a/src/jinja/client.py
+++ b/src/jinja/client.py
@@ -1,0 +1,61 @@
+from dataclasses import dataclass
+from typing import Dict, List
+
+import yaml
+from jinja2 import BaseLoader, Environment
+from src.jinja.models import Parameter, Response
+from src.s3.client import S3Client
+from src.utils.log import Logger
+
+log = Logger(__name__).get_logger()
+
+
+@dataclass
+class TemplateEngine:
+    """
+    Template Engine
+
+    This class is utilized to create parameterized templates with Jinja.
+    The responses from Bedrock are fed into this class to be used in the
+    template to create the newsletter.
+    """
+
+    OUTPUT_FILE = "templates/index.html"
+    DEFAULT_TEMPLATE = "default"
+
+    s3_client: S3Client
+
+    def __post_init__(self) -> None:
+        log.debug("Creating TemplateGenerator client")
+
+    def get_template_spec(
+        self, template_name: str = DEFAULT_TEMPLATE
+    ) -> List[Parameter]:
+        log.info(f"Getting template spec for template: '{template_name}'")
+        parameters = []
+        for parameter in yaml.safe_load(self.s3_client.get_template_spec())[
+            "TemplateSpec"
+        ]["Parameters"]:
+            parameters.append(Parameter(parameter["Key"], parameter["Prompt"]))
+        return parameters
+
+    def render_template(
+        self, template_name: str = DEFAULT_TEMPLATE, responses: List[Response] = []
+    ) -> None:
+        log.info(f"Rendering template: '{template_name}'")
+        with open(TemplateEngine.OUTPUT_FILE, "w") as f:
+            template = self.s3_client.get_template(template_name)
+            environment = Environment(loader=BaseLoader).from_string(template)
+            rendered_template = environment.render(
+                **TemplateEngine._convert_responses_to_dict(responses)
+            )
+            self.s3_client.put_newsletter(template_name, rendered_template)
+            f.write(rendered_template)
+        log.info(f"Finished rendering template: '{template_name}'")
+
+    @staticmethod
+    def _convert_responses_to_dict(responses: List[Response]) -> Dict[str, str]:
+        responses_dict = {}
+        for response in responses:
+            responses_dict[response.key] = response.response
+        return responses_dict

--- a/src/jinja/models.py
+++ b/src/jinja/models.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Parameter:
+    key: str
+    prompt: str
+
+
+@dataclass
+class Response:
+    key: str
+    response: str

--- a/src/s3/client.py
+++ b/src/s3/client.py
@@ -4,6 +4,7 @@ from mypy_boto3_s3 import S3Client
 from src.environment import Domain
 from src.utils.log import Logger
 
+
 log = Logger(__name__).get_logger()
 
 
@@ -17,6 +18,12 @@ class S3Client:
     """
 
     REPORTS_BUCKET_NAME_FORMAT = "walterai-reports-{domain}"
+    TEMPLATES_DIR = "templates"
+    DEFAULT_TEMPLATE = "default"
+    TEMPLATE_SPEC = "templatespec.yml"
+    TEMPLATE = "template.jinja"
+    NEWSLETTERS_DIR = "newsletters"
+    NEWSLETTER = "index.html"
 
     client: S3Client
     domain: Domain
@@ -27,10 +34,45 @@ class S3Client:
         log.debug(
             f"Creating {self.domain.value} S3 client in region '{self.client.meta.region_name}'"
         )
-        self.bucket = self._get_reports_bucket_name(self.domain)
+        self.bucket = S3Client._get_reports_bucket_name(self.domain)
 
-    def put_report(self) -> None:
-        pass
+    def get_template_spec(self, template_name: str = DEFAULT_TEMPLATE) -> None:
+        key = S3Client._get_template_spec_key(template_name)
+        log.info(f"Getting template spec from bucket '{self.bucket}' with key '{key}'")
+        return self.get_object(key)
 
-    def _get_reports_bucket_name(self, domain: Domain) -> str:
+    def get_template(self, template_name: str = DEFAULT_TEMPLATE) -> None:
+        key = S3Client._get_template_key(template_name)
+        log.info(f"Getting template from bucket '{self.bucket}' with key '{key}'")
+        return self.get_object(key)
+
+    def get_object(self, key: str) -> str:
+        return (
+            self.client.get_object(Bucket=self.bucket, Key=key)["Body"]
+            .read()
+            .decode("utf-8")
+        )
+
+    def put_newsletter(self, template: str, contents: str) -> None:
+        key = S3Client._get_newsletter_key(template)
+        log.info(f"Dumping newsletter to bucket '{self.bucket}' with key '{key}'")
+        self.put_object(key, contents)
+
+    def put_object(self, key: str, contents: str) -> None:
+        self.client.put_object(Bucket=self.bucket, Key=key, Body=contents)
+
+    @staticmethod
+    def _get_reports_bucket_name(domain: Domain) -> str:
         return S3Client.REPORTS_BUCKET_NAME_FORMAT.format(domain=domain.value)
+
+    @staticmethod
+    def _get_template_spec_key(template_name: str) -> str:
+        return f"{S3Client.TEMPLATES_DIR}/{template_name}/{S3Client.TEMPLATE_SPEC}"
+
+    @staticmethod
+    def _get_template_key(template_name: str) -> str:
+        return f"{S3Client.TEMPLATES_DIR}/{template_name}/{S3Client.TEMPLATE}"
+
+    @staticmethod
+    def _get_newsletter_key(template_name: str) -> str:
+        return f"{S3Client.NEWSLETTERS_DIR}/{template_name}/{S3Client.NEWSLETTER}"


### PR DESCRIPTION
This PR pulls newsletter templates from S3 for `WalterAIBackend` to render with responses from BedRock via Jinja.

The Lambda function pulls a `templatespec.yml` that tells Walter what to get from BedRock and where to render it in the Jinja template. An example spec file is given below:

```yaml
version: 0.0

TemplateSpec:
  Parameters:
    - Key: graphic_text
      Prompt: |
        Introduce yourself as WalterAI an artificially intelligent bot that sends a daily financial newsletter in a business-casual fashion. No more than three sentences.
    - Key: good_text
      Prompt: |
        Say something good about the stock market in four sentences or less.
    - Key: bad_text
      Prompt: |
        Say something bad about the stock market in four sentences or less.
    - Key: joke_text
      Prompt: |
        Tell a joke in a couple of sentences or less.
    - Key: who_am_i_text
      Prompt: |
        Say something about the existence of AI and how bizarre it is in 6 sentences or less.
```

The newsletter template is also stored in S3 and pulled by Walter before rendering with the generative AI responses and sending to users (will also be dumped to S3 as well for artifact purposes).