### PR TITLE
fix: Don't write rendered template to disk

### DIFF
--- a/buildspec.py
+++ b/buildspec.py
@@ -83,7 +83,7 @@ def describe_change_set(client: CloudFormationClient) -> str:
 
 
 def change_set_contains_changes(status: str) -> bool:
-    return status in ["CREATE_PENDING", "CREATE_IN_PROGRESS", "CREATE_COMPLETED"]
+    return status in ["CREATE_PENDING", "CREATE_IN_PROGRESS", "CREATE_COMPLETE"]
 
 
 def execute_change_set(client: CloudFormationClient) -> None:

--- a/infra/infra.yml
+++ b/infra/infra.yml
@@ -320,6 +320,7 @@ Resources:
         Statement: 
           - Action: 
               - "s3:PutObject"
+              - "s3:GetObject"
             Effect: Allow
             Resource: !Join
               - ""

--- a/src/jinja/client.py
+++ b/src/jinja/client.py
@@ -20,7 +20,7 @@ class TemplateEngine:
     template to create the newsletter.
     """
 
-    OUTPUT_FILE = "templates/index.html"
+    OUTPUT_FILE = "tmp/index.html"
     DEFAULT_TEMPLATE = "default"
 
     s3_client: S3Client
@@ -43,14 +43,12 @@ class TemplateEngine:
         self, template_name: str = DEFAULT_TEMPLATE, responses: List[Response] = []
     ) -> None:
         log.info(f"Rendering template: '{template_name}'")
-        with open(TemplateEngine.OUTPUT_FILE, "w") as f:
-            template = self.s3_client.get_template(template_name)
-            environment = Environment(loader=BaseLoader).from_string(template)
-            rendered_template = environment.render(
-                **TemplateEngine._convert_responses_to_dict(responses)
-            )
-            self.s3_client.put_newsletter(template_name, rendered_template)
-            f.write(rendered_template)
+        template = self.s3_client.get_template(template_name)
+        environment = Environment(loader=BaseLoader).from_string(template)
+        rendered_template = environment.render(
+            **TemplateEngine._convert_responses_to_dict(responses)
+        )
+        self.s3_client.put_newsletter(template_name, rendered_template)
         log.info(f"Finished rendering template: '{template_name}'")
 
     @staticmethod


### PR DESCRIPTION
Lambda runtime environments have 512MB of temporary storage. This CR ensures that Walter does not write any templates to Lambda storage and instead keeps everything in memory and puts/gets from S3. 