### PR TITLE
fix: Add SES permissions to Lambda

### DIFF
--- a/infra/infra.yml
+++ b/infra/infra.yml
@@ -212,6 +212,20 @@ Resources:
       Roles:
         - !Ref WalterLambdaRole
 
+  SimpleEmailSerivceAccessPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: !Sub "SimpleEmailServiceAccessPolicy-${AppEnvironment}"
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - "ses:Send*"
+            Resource: "*"
+      Roles:
+        - !Ref WalterLambdaRole
+
   StocksTableAccessPolicy:
     Type: AWS::IAM::Policy
     Properties:


### PR DESCRIPTION
This CR adds SES send email permissions to the Lambda execution role used by `WalterAIBackend` service. 

Fixes issues with not being able to send email from Lambda but able to send emails locally (due to greater IAM user privileges). 